### PR TITLE
Add result object that holds response and has helper methods

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,7 +8,7 @@ filter:
 build:
     environment:
         php:
-            version: 7.0
+            version: 7.0.8
     dependencies:
         before:
             - composer require symfony/symfony:3.0.*

--- a/Api/CurrentWeatherData.php
+++ b/Api/CurrentWeatherData.php
@@ -41,7 +41,8 @@ class CurrentWeatherData
      * @throws BadRequestException
      * @throws GuzzleException
      */
-    private function sendRequest(array $params) : ResponseInterface {
+    private function sendRequest(array $params) : ResponseInterface
+    {
         $params = array_merge(['appid' => $this->apiKey], $params);
 
         try {
@@ -84,15 +85,15 @@ class CurrentWeatherData
      *
      * @param string $cityName
      * @param string $countryCode optional country code in ISO 3166-1 alpha-2 format
-     * @return \stdClass
+     * @return CurrentWeatherDataResult
      * @throws GuzzleException on request exception
      * @throws BadRequestException
      * @throws InvalidCountryCodeException on incorrect country code
      */
-    public function loadByCityName(string $cityName, string $countryCode = null) : \stdClass
+    public function loadByCityName(string $cityName, string $countryCode = null) : CurrentWeatherDataResult
     {
-        return json_decode(
-            $this->sendRequest(['q' => $this->addCountryCodeToBase($cityName, $countryCode)])->getBody()
+        return CurrentWeatherDataResult::fromApiResponse(
+            $this->sendRequest(['q' => $this->addCountryCodeToBase($cityName, $countryCode)])
         );
     }
 
@@ -100,27 +101,27 @@ class CurrentWeatherData
      * Call by city id
      *
      * @param string $cityCode
-     * @return \stdClass
+     * @return CurrentWeatherDataResult
      * @throws GuzzleException on request exception
      * @throws BadRequestException
      */
-    public function loadByCityId(string $cityCode) : \stdClass
+    public function loadByCityId(string $cityCode) : CurrentWeatherDataResult
     {
-        return json_decode($this->sendRequest(['id' => $cityCode])->getBody());
+        return CurrentWeatherDataResult::fromApiResponse($this->sendRequest(['id' => $cityCode]));
     }
 
     /**
      * Call by geographic coordinates
      *
-     * @param float $lat location latitude 
+     * @param float $lat location latitude
      * @param float $lon location longitude
-     * @return \stdClass
+     * @return CurrentWeatherDataResult
      * @throws GuzzleException on request exception
      * @throws BadRequestException
      */
-    public function loadByGeographicCoordinates(float $lat, float $lon) : \stdClass
+    public function loadByGeographicCoordinates(float $lat, float $lon) : CurrentWeatherDataResult
     {
-        return json_decode($this->sendRequest(['lat' => $lat, 'lon' => $lon])->getBody());
+        return CurrentWeatherDataResult::fromApiResponse($this->sendRequest(['lat' => $lat, 'lon' => $lon]));
     }
 
     /**
@@ -128,15 +129,15 @@ class CurrentWeatherData
      *
      * @param string $zipCode zip code
      * @param string $countryCode optional country code in ISO 3166-1 alpha-2 format
-     * @return \stdClass
+     * @return CurrentWeatherDataResult
      * @throws GuzzleException on request exception
      * @throws BadRequestException
      * @throws InvalidCountryCodeException on incorrect country code
      */
-    public function loadByZipCode(string $zipCode, string $countryCode = null) : \stdClass
+    public function loadByZipCode(string $zipCode, string $countryCode = null) : CurrentWeatherDataResult
     {
-        return json_decode(
-            $this->sendRequest(['zip' => $this->addCountryCodeToBase($zipCode, $countryCode)])->getBody()
+        return CurrentWeatherDataResult::fromApiResponse(
+            $this->sendRequest(['zip' => $this->addCountryCodeToBase($zipCode, $countryCode)])
         );
     }
 

--- a/Api/CurrentWeatherDataResult.php
+++ b/Api/CurrentWeatherDataResult.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Savchenko\Bundle\OpenWeatherMapBundle\Api;
+
+use Psr\Http\Message\ResponseInterface;
+
+class CurrentWeatherDataResult
+{
+    private $data;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    private function __construct($data, ResponseInterface $response = null)
+    {
+        $this->data = $data;
+
+        if ($response) {
+            $this->response = $response;
+        }
+
+    }
+
+    /**
+     * @param string $jsonString
+     * @return CurrentWeatherDataResult
+     */
+    public static function fromJsonString($jsonString)
+    {
+        return new self(json_decode($jsonString));
+    }
+
+    public static function fromApiResponse(ResponseInterface $response)
+    {
+        return new self(json_decode($response->getBody()), $response);
+    }
+
+    /**
+     * @return ResponseInterface
+     */
+    public function getResponse()
+    {
+        if ($this->response) {
+            return $this->response;
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function asArray()
+    {
+        return json_decode($this->asJson(), true);
+    }
+
+    /**
+     * @return string
+     */
+    public function asJson()
+    {
+        return json_encode($this->data);
+    }
+
+    public function __get($name)
+    {
+        if (property_exists($this->data, $name)) {
+            return $this->data->{$name};
+        }
+
+        throw new \InvalidArgumentException('Key not found in result');
+    }
+}

--- a/Tests/Api/CurrentWeatherDataResultTest.php
+++ b/Tests/Api/CurrentWeatherDataResultTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Savchenko\Bundle\OpenWeatherMapBundle\Tests\Api;
+
+use GuzzleHttp\Psr7\Response;
+use Savchenko\Bundle\OpenWeatherMapBundle\Api\CurrentWeatherDataResult;
+
+class CurrentWeatherDataResultTest extends \PHPUnit_Framework_TestCase
+{
+    use FakeWeatherDataTrait;
+
+    private $response;
+
+    public function setUp()
+    {
+
+        $this->response = $this->prophesize(Response::class);
+    }
+
+    /**
+     * @test
+     */
+    public function It_should_save_the_response_when_constructed_from_response()
+    {
+
+        $this->response->getBody()->willReturn($this->getWeatherData());
+
+        $sut = CurrentWeatherDataResult::fromApiResponse($this->response->reveal());
+        $this->assertSame('London', $sut->name);
+        $this->assertSame($this->response->reveal(), $sut->getResponse());
+
+    }
+
+    /**
+     * @test
+     */
+    public function The_result_can_be_rendered_as_array()
+    {
+
+        $this->response->getBody()->willReturn($this->getWeatherData());
+
+        $sut = CurrentWeatherDataResult::fromApiResponse($this->response->reveal());
+        $this->assertSame($this->getWeatherData(), $sut->asJson());
+
+    }
+
+    /**
+     * @test
+     */
+    public function The_result_can_be_rendered_as_json()
+    {
+
+        $this->response->getBody()->willReturn($this->getWeatherData());
+        $sut = CurrentWeatherDataResult::fromApiResponse($this->response->reveal());
+        $this->assertSame('London', $sut->asArray()['name']);
+
+    }
+
+}

--- a/Tests/Api/CurrentWeatherDataTest.php
+++ b/Tests/Api/CurrentWeatherDataTest.php
@@ -10,6 +10,9 @@ use Savchenko\Bundle\OpenWeatherMapBundle\Api\CurrentWeatherData;
 
 class CurrentWeatherDataTest extends \PHPUnit_Framework_TestCase
 {
+
+    use FakeWeatherDataTrait;
+
     /**
      * @var Client|\PHPUnit_Framework_MockObject_MockObject
      */
@@ -18,49 +21,6 @@ class CurrentWeatherDataTest extends \PHPUnit_Framework_TestCase
      * @var CurrentWeatherData
      */
     protected $currentWeatherData;
-
-    /**
-     * Get OpenWeatherMap response example
-     *
-     * @return string
-     */
-    protected function getWeatherData()
-    {
-        return json_encode([
-            'coord' => [
-                'lon' => -0.13,
-                'lat' => 51.51,
-            ],
-            'weather' => [[
-                'id' => 800,
-                'main' => 'Clear',
-                'description' => 'clear sky',
-                'icon' => '01n',
-            ]],
-            'main' => [
-                'temp' => 282.94,
-                'pressure' => 1007,
-                'humidity' => 71,
-                'temp_min' => 281.15,
-                'temp_max' => 285.25,
-            ],
-            'wind' => [
-                'speed' => 3.6,
-                'deg' => 100,
-            ],
-            'clouds' => [
-                'all' => 0,
-            ],
-            'dt' => 1460493742,
-            'sys' => [
-                'country' => 'GB',
-                'sunrise' => 1460437723,
-                'sunset' => 1460487258,
-            ],
-            'id' => 2643743,
-            'name' => 'London',
-        ]);
-    }
 
     /**
      * {@inheritdoc}

--- a/Tests/Api/FakeWeatherDataTrait.php
+++ b/Tests/Api/FakeWeatherDataTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Savchenko\Bundle\OpenWeatherMapBundle\Tests\Api;
+
+trait FakeWeatherDataTrait
+{
+
+    /**
+     * Get OpenWeatherMap response example
+     *
+     * @return string
+     */
+    protected function getWeatherData()
+    {
+        return json_encode(
+            [
+                'coord' => [
+                    'lon' => -0.13,
+                    'lat' => 51.51,
+                ],
+                'weather' => [
+                    [
+                        'id' => 800,
+                        'main' => 'Clear',
+                        'description' => 'clear sky',
+                        'icon' => '01n',
+                    ],
+                ],
+                'main' => [
+                    'temp' => 282.94,
+                    'pressure' => 1007,
+                    'humidity' => 71,
+                    'temp_min' => 281.15,
+                    'temp_max' => 285.25,
+                ],
+                'wind' => [
+                    'speed' => 3.6,
+                    'deg' => 100,
+                ],
+                'clouds' => [
+                    'all' => 0,
+                ],
+                'dt' => 1460493742,
+                'sys' => [
+                    'country' => 'GB',
+                    'sunrise' => 1460437723,
+                    'sunset' => 1460487258,
+                ],
+                'id' => 2643743,
+                'name' => 'London',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a result object that wraps the result object.

The result object has two helper methods: `->asArray()` and `->asJson()`
and delegates the property access via magic call to the wrapped result.
